### PR TITLE
Fix/vocabularyをdevelopへマージ

### DIFF
--- a/api/.rubocop.yml
+++ b/api/.rubocop.yml
@@ -15,7 +15,7 @@ Style/HashSyntax:
 
 Metrix/MethodLength:
   CountComments: false
-  Max: 15
+  Max: 20
   Exclude:
    - 'app/controllers/concerns/assign_token.rb'
    - 'app/service/openai/*'

--- a/api/app/controllers/api/v1/wordcard/vocabularies_controller.rb
+++ b/api/app/controllers/api/v1/wordcard/vocabularies_controller.rb
@@ -17,14 +17,18 @@ class Api::V1::Wordcard::VocabulariesController < Api::V1::BaseController
   end
 
   def create
-    Vocabulary.save_vocabulary_with_roles!(card: @card, vocabularies_params: vocabularies_params)
+    vocabulary = Vocabulary.new
+    vocabulary.save_vocabulary_with_roles_test(card: @card, vocabularies_params: vocabularies_params)
+    # Vocabulary.save_vocabulary_with_roles!(card: @card, vocabularies_params: vocabularies_params)
     render json: { message: "単語を登録しました" }, status: :ok
   rescue ActiveRecord::RecordInvalid => e
     render json: { error: e.record.errors.full_messages }, status: :unprocessable_entity
   end
 
   def update
-    Vocabulary.update_vocabulary_with_roles!(card: @card, vocabularies_params: vocabularies_params)
+    vocabulary = Vocabulary.new
+    vocabulary.save_vocabulary_with_roles_test(card: @card, vocabularies_params: vocabularies_params)
+    # Vocabulary.update_vocabulary_with_roles!(card: @card, vocabularies_params: vocabularies_params)
     render json: { message: "単語を更新しました" }, status: :ok
   rescue ActiveRecord::RecordInvalid => e
     render json: { error: e.record.errors.full_messages }, status: :unprocessable_entity
@@ -62,6 +66,6 @@ class Api::V1::Wordcard::VocabulariesController < Api::V1::BaseController
 
     def set_card
       @card = current_user.cards.find_by(uuid: params[:card_uuid])
-      render json: { message: "単語帳が見つかりません" }, status: :not_found unless @card
+      render json: { error: "単語帳が見つかりません" }, status: :not_found unless @card
     end
 end

--- a/api/app/controllers/api/v1/wordcard/vocabularies_controller.rb
+++ b/api/app/controllers/api/v1/wordcard/vocabularies_controller.rb
@@ -17,18 +17,15 @@ class Api::V1::Wordcard::VocabulariesController < Api::V1::BaseController
   end
 
   def create
-    vocabulary = Vocabulary.new
-    vocabulary.save_vocabulary_with_roles_test(card: @card, vocabularies_params: vocabularies_params)
-    # Vocabulary.save_vocabulary_with_roles!(card: @card, vocabularies_params: vocabularies_params)
-    render json: { message: "単語を登録しました" }, status: :ok
+    if Vocabulary.save_vocabulary_with_roles_test(card: @card, vocabularies_params: vocabularies_params)
+      render json: { message: "単語を登録しました" }, status: :ok
+    end
   rescue ActiveRecord::RecordInvalid => e
     render json: { error: e.record.errors.full_messages }, status: :unprocessable_entity
   end
 
   def update
-    vocabulary = Vocabulary.new
-    vocabulary.save_vocabulary_with_roles_test(card: @card, vocabularies_params: vocabularies_params)
-    # Vocabulary.update_vocabulary_with_roles!(card: @card, vocabularies_params: vocabularies_params)
+    Vocabulary.update_vocabulary_with_roles_test(card: @card, vocabularies_params: vocabularies_params)
     render json: { message: "単語を更新しました" }, status: :ok
   rescue ActiveRecord::RecordInvalid => e
     render json: { error: e.record.errors.full_messages }, status: :unprocessable_entity

--- a/api/app/controllers/api/v1/wordcard/vocabularies_controller.rb
+++ b/api/app/controllers/api/v1/wordcard/vocabularies_controller.rb
@@ -17,20 +17,23 @@ class Api::V1::Wordcard::VocabulariesController < Api::V1::BaseController
   end
 
   def create
-    if Vocabulary.save_vocabulary_with_roles_test(card: @card, vocabularies_params: vocabularies_params)
+    status, error_message = Vocabulary.save_vocabulary_with_roles(card: @card, vocabularies_params: vocabularies_params)
+
+    if status
       render json: { message: "単語を登録しました" }, status: :ok
+    else
+      render json: { error: error_message }, status: :internal_server_error
     end
-  rescue ActiveRecord::RecordInvalid => e
-    render json: { error: e.record.errors.full_messages }, status: :unprocessable_entity
   end
 
   def update
-    Vocabulary.update_vocabulary_with_roles_test(card: @card, vocabularies_params: vocabularies_params)
-    render json: { message: "単語を更新しました" }, status: :ok
-  rescue ActiveRecord::RecordInvalid => e
-    render json: { error: e.record.errors.full_messages }, status: :unprocessable_entity
-  rescue ActiveRecord::RecordNotFound => e
-    render json: { error: e.message }, status: :not_found
+    status, error_message = Vocabulary.save_vocabulary_with_roles(card: @card, vocabularies_params: vocabularies_params)
+
+    if status
+      render json: { message: "単語を更新しました" }, status: :ok
+    else
+      render json: { error: error_message }, status: :internal_server_error
+    end
   end
 
   def update_conjugation

--- a/api/app/controllers/api/v1/wordcard/vocabularies_controller.rb
+++ b/api/app/controllers/api/v1/wordcard/vocabularies_controller.rb
@@ -36,15 +36,6 @@ class Api::V1::Wordcard::VocabulariesController < Api::V1::BaseController
     end
   end
 
-  def update_conjugation
-    Vocabulary.update_verb_conjugation!(card: @card, vocabularies_params: vocabularies_params)
-    render json: { message: "単語を更新しました" }, status: :ok
-  rescue ActiveRecord::RecordInvalid => e
-    render json: { error: e.record.errors.full_messages }, status: :unprocessable_entity
-  rescue ActiveRecord::RecordNotFound => e
-    render json: { error: e.message }, status: :not_found
-  end
-
   def destroy
     vocabulary = @card.vocabularies.find(params[:id])
     if vocabulary.destroy

--- a/api/app/models/vocabulary.rb
+++ b/api/app/models/vocabulary.rb
@@ -11,65 +11,87 @@ class Vocabulary < ApplicationRecord
 
   scope :with_role, ->(role_name) { joins(:roles).where(roles: { name: role_name }) }
 
-  def self.save_vocabulary_with_roles!(card:, vocabularies_params:)
-    binding.pry
+  # def self.save_vocabulary_with_roles!(card:, vocabularies_params:)
+  #   binding.pry
+  #   ActiveRecord::Base.transaction do
+  #     vocabularies_params.each do |vocabulary_params|
+  #       vocabulary = card.vocabularies.new(vocabulary_params.permit(:word, :meaning))
+
+  #       role_names = vocabulary_params[:roles]
+  #       vocabulary.roles = role_names.map {|name| Role.find_or_initialize_by(name: name) }
+
+  #       vocabulary.save!
+  #     end
+  #   end
+  # rescue ActiveRecord::Rollback
+  #   false
+  # end
+
+  # def self.update_vocabulary_with_roles!(card:, vocabularies_params:)
+    
+  #   binding.pry
+    
+  #   ActiveRecord::Base.transaction do
+  #     vocabularies_params.each do |vocabulary_params|
+  #       vocabulary = card.vocabularies.find_by!(vocabulary_params.permit(:id))
+  #       vocabulary.assign_attributes(vocabulary_params.permit(:word, :meaning))
+
+  #       role_names = vocabulary_params[:roles]
+
+  #       unless role_names.nil?
+  #         vocabulary.roles.clear
+  #         vocabulary.roles = role_names.map {|name| Role.find_or_initialize_by(name: name) }
+  #       end
+
+  #       vocabulary.save!
+  #     end
+  #   end
+  # rescue ActiveRecord::Rollback
+  #   false
+  # end
+
+  def self.save_vocabulary_with_roles_test(card:, vocabularies_params:)
     ActiveRecord::Base.transaction do
       vocabularies_params.each do |vocabulary_params|
         vocabulary = card.vocabularies.new(vocabulary_params.permit(:word, :meaning))
+        roles = vocabulary_params[:roles]
 
-        role_names = vocabulary_params[:roles]
-        vocabulary.roles = role_names.map {|name| Role.find_or_initialize_by(name: name) }
+        if roles.empty?
+          vocabulary.roles = []
+        else
+          new_roles = roles.map {|name| Role.find_or_initialize_by(name: name) }
+          vocabulary.roles = new_roles
+        end
 
         vocabulary.save!
       end
+      true
     end
   rescue ActiveRecord::Rollback
     false
   end
 
-  def self.update_vocabulary_with_roles!(card:, vocabularies_params:)
-    
-    binding.pry
-    
+
+  def self.update_vocabulary_with_roles_test(card:, vocabularies_params:)
     ActiveRecord::Base.transaction do
       vocabularies_params.each do |vocabulary_params|
         vocabulary = card.vocabularies.find_by!(vocabulary_params.permit(:id))
         vocabulary.assign_attributes(vocabulary_params.permit(:word, :meaning))
-
-        role_names = vocabulary_params[:roles]
-
-        unless role_names.nil?
-          vocabulary.roles.clear
-          vocabulary.roles = role_names.map {|name| Role.find_or_initialize_by(name: name) }
-        end
-
-        vocabulary.save!
-      end
-    end
-  rescue ActiveRecord::Rollback
-    false
-  end
-
-  def save_vocabulary_with_roles_test(card:, vocabularies_params:)
-    ActiveRecord::Base.transaction do
-      vocabularies_params.each do |vocabulary_params|
-        if vocabulary_params[:id].present?
-          vocabulary = card.vocabularies.find_by!(vocabulary_params.permit(:id))
-          vocabulary.assign_attributes(vocabulary_params.permit(:word))
-        else
-          vocabulary = card.vocabularies.new(vocabulary_params.permit(:word, :meaning))
-        end
-        
-        
-        # binding.pry
-        
         roles = vocabulary_params[:roles]
-        vocabulary.roles = roles.map {|name| Role.find_or_initialize_by(name: name) }
+
+        if roles.empty?
+          vocabulary.roles = []
+        else
+          new_roles = roles.map {|name| Role.find_or_initialize_by(name: name) }
+          vocabulary.roles = new_roles
+        end
 
         vocabulary.save!
       end
+      true
     end
-  rescue ActiveRecord::Rollback
+  # rescue ActiveRecord::Rollback
+  rescue ActiveRecord::RecordInvalid
     false
   end
 

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -20,7 +20,6 @@ Rails.application.routes.draw do
 
           resources :vocabularies, only: [:index, :create, :destroy]
           patch "vocabularies/update", to: "vocabularies#update"
-          patch "vocabularies/update_conjugation", to: "vocabularies#update_conjugation"
           post "conjugation/create", to: "chat#create"
 
           resource :like, only: [:create, :destroy]


### PR DESCRIPTION
### 変更内容
## API
- vocabulary_controllerの全体をリファクタリング
-> create・updateメソッド内で使用するsaveメソッドの共通化
- vocabularyモデル：save_with_rolesメソッドの共通化
-> 作成用と更新用で分離していたが、共通化
- update_conjugationメソッドの削除
-> 上記メソッド共通化で不要になったため

## Front
- API側のメソッド共通化による、JSONの修正
- cookie対応